### PR TITLE
fix: correct typo of 'Github' to 'GitHub' on sign in button

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           href="https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97"
         >
           <button class="login-btn-text">
-            Sign In With Github
+            Sign In With GitHub
             <img class="logo" src="img/github.png" alt="Github Icon" />
           </button>
         </a>

--- a/releases.html
+++ b/releases.html
@@ -66,7 +66,7 @@
           href="https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97"
         >
           <button class="login-btn-text">
-            Sign In With Github
+            Sign In With GitHub
             <img class="logo" src="img/github.png" alt="Github Icon" />
           </button>
         </a>


### PR DESCRIPTION
Fix for Issue #165 

Updated the button label text for the GitHub Sign In:

<img width="222" alt="Screen Shot 2021-10-23 at 9 50 13 PM" src="https://user-images.githubusercontent.com/22095244/138576861-24cc413c-532c-48b6-804a-32ab4603c7a8.png">
