### PR TITLE
Changed logo width to 400px to match height. Made height explicit.

### DIFF
--- a/css/events.css
+++ b/css/events.css
@@ -3,7 +3,8 @@
 }
 
 .logo-img {
-  width: 150px;
+  width: 400px;
+  height: 400px;
   display: block;
   margin: 10px auto;
 }


### PR DESCRIPTION
### Issue
This PR solves issue #203.

### What is the change?
After investigating the logo in developer tools, the computed height is 400px. I matched the width to the computed height and then made the computed height explicit by including it in the `logo-img` class.

### Is Development Tested?

- [x] Yes
- [ ] No

### Before / After Change Screenshots

#### Before:
![image](https://user-images.githubusercontent.com/65432314/148442788-d640592e-c2a8-4317-bb18-62a9be36959c.png)

#### After:
![image](https://user-images.githubusercontent.com/65432314/148442815-3f3803fa-a2f3-4041-abdb-3f0bc46273a0.png)
