### PR TITLE
style: btn-login-text updated

### DIFF
--- a/css/navbar.css
+++ b/css/navbar.css
@@ -50,13 +50,18 @@ nav li a:hover {
   display: none;
 }
 
-.btn-login-text {
+.btn-login-text{
   border-radius: 6px;
   padding: 5px;
   background-color: #1d1283;
   color: white;
   cursor: pointer;
   border: 2px solid white;
+  display: flex;
+}
+
+.btn-login-text img{
+  padding-left: 0.3rem;
 }
 
 .user-greet {

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -50,7 +50,7 @@ nav li a:hover {
   display: none;
 }
 
-.btn-login-text{
+.btn-login-text {
   border-radius: 6px;
   padding: 5px;
   background-color: #1d1283;
@@ -60,7 +60,7 @@ nav li a:hover {
   display: flex;
 }
 
-.btn-login-text img{
+.btn-login-text img {
   padding-left: 0.3rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
           href="https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97"
         >
           <button class="btn-login-text">
-            Sign In
-            <img
+            Sign In 
+              <img              
               src="img/github.png"
               alt="GitHub Icon"
               height="15px"

--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
           href="https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97"
         >
           <button class="btn-login-text">
-            Sign In 
-              <img              
+            Sign In
+            <img
               src="img/github.png"
               alt="GitHub Icon"
               height="15px"


### PR DESCRIPTION
### Issue
#219 issue is resolve

### What is the change?

-Done the styling of Github sign in button
-Make the text and logo in one line

### Is Development Tested?

-  Yes

### Before / After Change Screenshots

Before :
![unknown](https://user-images.githubusercontent.com/82635500/149755574-db8e442d-9351-4ba4-86f4-44f08738e44d.png)



After :
<img width="141" alt="Untitled" src="https://user-images.githubusercontent.com/82635500/149756567-ea9a496c-eb73-4e5f-b374-0234c08b8097.png">

mobile view :
<img width="209" alt="Untitled1" src="https://user-images.githubusercontent.com/82635500/149821453-16fed294-4957-43f7-86d8-a256ffe43919.png">


