### PR TITLE
added standardized image sizing to member images

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -53,11 +53,20 @@ const getMemberImgs = () => {
     .then((res) => {
       const { members } = res;
       for (const { isMember, username, picture } of members) {
+        let adjustedPicture = '';
+        if (!!picture) {
+          adjustedPicture = `${picture.url.slice(
+            0,
+            53,
+          )}w_200,h_200${picture.url.slice(52)}`;
+        } else {
+          adjustedPicture = picture;
+        }
         memberImgArray.push({
           isMember,
           username,
           img_url:
-            picture?.url ||
+            adjustedPicture ||
             'https://raw.githubusercontent.com/Real-Dev-Squad/website-www/2271f2ee9834ebabfc102dbc0f8c4848673fc283/img/profile.png',
           member_url: getMemberURL(username),
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "pre-commit": "^1.2.2",
-        "prettier": "2.2.1"
+        "prettier": "^2.2.1"
       }
     },
     "node_modules/buffer-from": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "pre-commit": "^1.2.2",
-    "prettier": "2.2.1"
+    "prettier": "^2.2.1"
   },
   "pre-commit": [
     "check"


### PR DESCRIPTION
### Issue

##### Example : Closes #255

### What is the change?

The member image URL's had varying sizes, so I added some preprocessing to the URL string that adds the following ensures a 200x200 dimension picture like so:

`res.cloudinary.com/realdevsquad/image/upload/w_200,h_200/v1645293071/profile/XAF7rSUvk4p0d098qWYS/ovew4w7n6zdmgy03yr3z.png`

### Is Development Tested?

- [ ] Yes
- [X] No (Didn't write any tests for it)

### Before / After Change Screenshots

N/A