### PR TITLE
fix/can redirect to login

### DIFF
--- a/js/github.js
+++ b/js/github.js
@@ -12,10 +12,7 @@ const doesGitHubCookieExist = () => {
 const updateGitHubLink = () => {
   const allLoginBtns = document.querySelectorAll('.btn-login');
   allLoginBtns.forEach((btn) => {
-    btn.setAttribute(
-      'href',
-      'https://github.realdevsquad.com',
-    );
+    btn.setAttribute('href', 'https://github.realdevsquad.com');
   });
 };
 

--- a/js/github.js
+++ b/js/github.js
@@ -12,7 +12,10 @@ const doesGitHubCookieExist = () => {
 const updateGitHubLink = () => {
   const allLoginBtns = document.querySelectorAll('.btn-login');
   allLoginBtns.forEach((btn) => {
-    btn.setAttribute('href', 'https://github.realdevsquad.com');
+    btn.setAttribute(
+      'href',
+      'https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97',
+    );
   });
 };
 

--- a/js/github.js
+++ b/js/github.js
@@ -14,7 +14,7 @@ const updateGitHubLink = () => {
   allLoginBtns.forEach((btn) => {
     btn.setAttribute(
       'href',
-      'https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97',
+      'https://github.realdevsquad.com',
     );
   });
 };

--- a/js/index.js
+++ b/js/index.js
@@ -69,9 +69,10 @@ const getMemberImgs = () => {
 
 if (doesGitHubCookieExist()) {
   window.addEventListener('DOMContentLoaded', fetchData);
-} else {
-  window.addEventListener('DOMContentLoaded', updateGitHubLink);
 }
+// else {
+//   window.addEventListener('DOMContentLoaded', updateGitHubLink);
+// }
 
 window.addEventListener('DOMContentLoaded', getMemberImgs);
 const modalTriggers = document.querySelectorAll('.popup-trigger');

--- a/js/index.js
+++ b/js/index.js
@@ -70,10 +70,6 @@ const getMemberImgs = () => {
 if (doesGitHubCookieExist()) {
   window.addEventListener('DOMContentLoaded', fetchData);
 }
-// the code redirects the user to fake page , commeting it to prevent user for redirection
-// else {
-//   window.addEventListener('DOMContentLoaded', updateGitHubLink);
-// }
 
 window.addEventListener('DOMContentLoaded', getMemberImgs);
 const modalTriggers = document.querySelectorAll('.popup-trigger');

--- a/js/index.js
+++ b/js/index.js
@@ -70,6 +70,7 @@ const getMemberImgs = () => {
 if (doesGitHubCookieExist()) {
   window.addEventListener('DOMContentLoaded', fetchData);
 }
+// the code redirects the user to fake page , commeting it to prevent user for redirection
 // else {
 //   window.addEventListener('DOMContentLoaded', updateGitHubLink);
 // }


### PR DESCRIPTION
### closes : #301 

### Issue :

- the user should not be redirected to the fake page when clicking on '**login with github** ' button , instead if GitHub is logged in the user should be redirected to the RDS homepage , if not logged in should be redirected to github login.

### Files Changed 

- index.js 

### Fixes :
The user will not be redirected to the fake page , will be redirected to the real github login page .

**For better understanding and more reference, Please read the issue ticket:** #301 

### Before fix video : 
https://www.loom.com/share/7b6d9439f31e4a43b07f7f5c3faff82c

### After fix video :
https://www.loom.com/share/31a39f610bb647fb9b6b1a6601fc2d89