### PR TITLE
add query param for join steps

### DIFF
--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -11,7 +11,10 @@ export default class StepperComponent extends Component {
   @service toast;
   @tracked preValid = false;
   @tracked isValid = JSON.parse(localStorage.getItem('isValid')) ?? false;
-  @tracked currentStep = +localStorage.getItem('currentStep') ?? 0;
+  @tracked currentStep =
+    +new URLSearchParams(window.location.search).get('step') ??
+    +localStorage.getItem('currentStep') ??
+    0;
   TITLE_MESSAGES = TITLE_MESSAGES;
   @tracked stepOneData = JSON.parse(localStorage.getItem('stepOneData'));
   @tracked stepTwoData = JSON.parse(localStorage.getItem('stepTwoData'));
@@ -25,6 +28,7 @@ export default class StepperComponent extends Component {
     if (this.currentStep < 5) {
       this.currentStep += 1;
       localStorage.setItem('currentStep', this.currentStep);
+      window.history.pushState({}, '', `?step=${this.currentStep}`);
     }
   }
 
@@ -32,6 +36,7 @@ export default class StepperComponent extends Component {
     if (this.currentStep > 0) {
       this.currentStep -= 1;
       localStorage.setItem('currentStep', this.currentStep);
+      window.history.pushState({}, '', `?step=${this.currentStep}`);
     }
   }
 

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -27,18 +27,18 @@ export default class StepperComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.router.transitionTo('join', {
-      queryParams: { step: localStorage.getItem('currentStep') },
-    });
+    window.onpopstate = () => {
+      this.currentStep = Number(
+        +new URLSearchParams(window.location.search).get('step')
+      );
+    };
   }
 
   @action incrementStep() {
     if (this.currentStep < 5) {
       this.currentStep += 1;
       localStorage.setItem('currentStep', this.currentStep);
-      this.router.transitionTo('join', {
-        queryParams: { step: this.currentStep },
-      });
+      this.router.transitionTo(`/join?step=${this.currentStep}`);
     }
   }
 
@@ -46,9 +46,7 @@ export default class StepperComponent extends Component {
     if (this.currentStep > 0) {
       this.currentStep -= 1;
       localStorage.setItem('currentStep', this.currentStep);
-      this.router.transitionTo('join', {
-        queryParams: { step: this.currentStep },
-      });
+      this.router.transitionTo(`/join?step=${this.currentStep}`);
     }
   }
 

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -38,6 +38,7 @@ export default class StepperComponent extends Component {
         },
       });
     }
+    window.history.pushState({}, '', `?step=${this.currentStep}`);
   }
 
   @action incrementStep() {

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -13,9 +13,7 @@ export default class StepperComponent extends Component {
   @tracked preValid = false;
   @tracked isValid = JSON.parse(localStorage.getItem('isValid')) ?? false;
   @tracked currentStep =
-    +localStorage.getItem('currentStep') ??
-    +new URLSearchParams(window.location.search).get('step') ??
-    0;
+    +localStorage.getItem('currentStep') ?? +this.args.step ?? 0;
   TITLE_MESSAGES = TITLE_MESSAGES;
   @tracked stepOneData = JSON.parse(localStorage.getItem('stepOneData'));
   @tracked stepTwoData = JSON.parse(localStorage.getItem('stepTwoData'));

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -37,7 +37,6 @@ export default class StepperComponent extends Component {
         },
       });
     }
-    window.history.pushState({}, '', `?step=${this.currentStep}`);
   }
 
   @action incrementStep() {

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -27,23 +27,18 @@ export default class StepperComponent extends Component {
 
   constructor() {
     super(...arguments);
-    if (
-      localStorage.getItem('currentStep') <=
-      new URLSearchParams(window.location.search).get('step')
-    ) {
-      this.router.transitionTo('join', {
-        queryParams: {
-          step: localStorage.getItem('currentStep'),
-        },
-      });
-    }
+    this.router.transitionTo('join', {
+      queryParams: { step: localStorage.getItem('currentStep') },
+    });
   }
 
   @action incrementStep() {
     if (this.currentStep < 5) {
       this.currentStep += 1;
       localStorage.setItem('currentStep', this.currentStep);
-      window.history.pushState({}, '', `?step=${this.currentStep}`);
+      this.router.transitionTo('join', {
+        queryParams: { step: this.currentStep },
+      });
     }
   }
 
@@ -51,7 +46,9 @@ export default class StepperComponent extends Component {
     if (this.currentStep > 0) {
       this.currentStep -= 1;
       localStorage.setItem('currentStep', this.currentStep);
-      window.history.pushState({}, '', `?step=${this.currentStep}`);
+      this.router.transitionTo('join', {
+        queryParams: { step: this.currentStep },
+      });
     }
   }
 

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -13,8 +13,8 @@ export default class StepperComponent extends Component {
   @tracked preValid = false;
   @tracked isValid = JSON.parse(localStorage.getItem('isValid')) ?? false;
   @tracked currentStep =
-    +new URLSearchParams(window.location.search).get('step') ??
     +localStorage.getItem('currentStep') ??
+    +new URLSearchParams(window.location.search).get('step') ??
     0;
   TITLE_MESSAGES = TITLE_MESSAGES;
   @tracked stepOneData = JSON.parse(localStorage.getItem('stepOneData'));
@@ -24,11 +24,19 @@ export default class StepperComponent extends Component {
 
   setIsValid = (newVal) => (this.isValid = newVal);
   setIsPreValid = (newVal) => (this.preValid = newVal);
+  queryParams = ['step'];
 
   constructor() {
     super(...arguments);
-    if (this.currentStep > 5 || this.currentStep < 0) {
-      this.router.transitionTo(`/page-not-found`);
+    if (
+      localStorage.getItem('currentStep') <=
+      new URLSearchParams(window.location.search).get('step')
+    ) {
+      this.router.transitionTo('join', {
+        queryParams: {
+          step: localStorage.getItem('currentStep'),
+        },
+      });
     }
   }
 

--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -9,6 +9,7 @@ import { JOIN_URL } from '../constants/apis';
 export default class StepperComponent extends Component {
   @service login;
   @service toast;
+  @service router;
   @tracked preValid = false;
   @tracked isValid = JSON.parse(localStorage.getItem('isValid')) ?? false;
   @tracked currentStep =
@@ -23,6 +24,13 @@ export default class StepperComponent extends Component {
 
   setIsValid = (newVal) => (this.isValid = newVal);
   setIsPreValid = (newVal) => (this.preValid = newVal);
+
+  constructor() {
+    super(...arguments);
+    if (this.currentStep > 5 || this.currentStep < 0) {
+      this.router.transitionTo(`/page-not-found`);
+    }
+  }
 
   @action incrementStep() {
     if (this.currentStep < 5) {

--- a/app/controllers/join.js
+++ b/app/controllers/join.js
@@ -4,5 +4,4 @@ import { inject as service } from '@ember/service';
 export default class JoinController extends Controller {
   @service router;
   queryParams = ['step'];
-  step = 0;
 }

--- a/app/controllers/join.js
+++ b/app/controllers/join.js
@@ -4,4 +4,5 @@ import { inject as service } from '@ember/service';
 export default class JoinController extends Controller {
   @service router;
   queryParams = ['step'];
+  step = 0;
 }

--- a/app/controllers/join.js
+++ b/app/controllers/join.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class JoinController extends Controller {
+  @service router;
+  queryParams = ['step'];
+}

--- a/tests/unit/controllers/join-test.js
+++ b/tests/unit/controllers/join-test.js
@@ -4,9 +4,13 @@ import { setupTest } from 'website-www/tests/helpers';
 module('Unit | Controller | join', function (hooks) {
   setupTest(hooks);
 
-  // TODO: Replace this with your real tests.
   test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:join');
     assert.ok(controller);
+  });
+
+  test('it has queryParams', function (assert) {
+    let controller = this.owner.lookup('controller:join');
+    assert.deepEqual(controller.queryParams, ['step']);
   });
 });

--- a/tests/unit/controllers/join-test.js
+++ b/tests/unit/controllers/join-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'website-www/tests/helpers';
+
+module('Unit | Controller | join', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:join');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
### Issue

##### Example : Closes #403

### What is the change?

1. `app/controllers/join.js` : This file contains the controller for the join route.
2. `app/components/stepper.js` : Add the query params to the stepper component.
3. `tests/unit/controllers/join-test.js` : Add the test for the join controller.
   - First we check `join` controller is exist or not.
   - Second we check `join` controller has expected the query params `step`.

### Is Development Tested?

- [ ] Yes
- [ ] No

### After Change Screenshots

https://user-images.githubusercontent.com/70854507/221082334-f5cf8095-f83a-42db-848a-fd36e37900a3.mp4

**Note:** We skip the test for the stepper component.
