### PR TITLE
feat: add year in event card

### DIFF
--- a/events.html
+++ b/events.html
@@ -155,7 +155,7 @@
             Building backend services can be challenging, but at Real Dev Squad,
             our members tackle interesting problems regularly.
           </h3>
-          <h3 class="event-date-time">Sunday, April 25th, 12:00pm IST</h3>
+          <h3 class="event-date-time">Sunday, April 25th 2021, 12:00pm IST</h3>
           <h2 class="speaker-name">
             Swaraj Rajpure
             <span class="speaker-social-info linkedin-info">
@@ -224,7 +224,7 @@
             Event Loop is an important core concept for web developers and
             interview questions
           </h3>
-          <h3 class="event-date-time">August 9th, 4pm IST</h3>
+          <h3 class="event-date-time">August 9th 2021, 4pm IST</h3>
           <h2 class="speaker-name">
             Vishwanath Arondekar
             <span class="speaker-social-info linkedin-info">


### PR DESCRIPTION
### Issue

##### Example : Closes #624 

### What is the change?

For a better user experience, we have added `year` as well along with the date of event. Earlier `year` was missing which can lead confusion to user considering the edge case where there are events with same date but with different years. 

### Is Development Tested?

- [X] Yes
- [ ] No

### Before / After Change Screenshots

#### Before Screenshot: 

![image](https://github.com/Real-Dev-Squad/website-www/assets/86982322/05d95d0a-fbce-4da6-b21e-8361f2d5f594)

#### After Screenshot: 

![image](https://github.com/Real-Dev-Squad/website-www/assets/86982322/f9617252-2ed9-4178-b4a2-a4b46e14bde8)
