### PR TITLE
[Onboarding Flow]- Add role option for a user on signup detail page

### DIFF
--- a/app/components/reusables/onboarding-input.hbs
+++ b/app/components/reusables/onboarding-input.hbs
@@ -7,6 +7,7 @@
   {{#if @required}}
     <span data-test-required={{@name}} class='required'>*</span>
   {{/if}}
+  {{! template-lint-disable no-down-event-binding  }}
   <input
     data-test-input-field={{@name}}
     name={{@name}}

--- a/app/components/signup-steps/step-one.hbs
+++ b/app/components/signup-steps/step-one.hbs
@@ -53,7 +53,7 @@
   @name='role'
   @placeHolder='Choose your role'
   @required={{true}}
-  @value={{this.data.country}}
+  @value={{this.data.role}}
   @options={{this.role}}
   @onChange={{this.inputHandler}}
 />

--- a/app/components/signup-steps/step-one.hbs
+++ b/app/components/signup-steps/step-one.hbs
@@ -57,3 +57,11 @@
   @options={{this.role}}
   @onChange={{this.inputHandler}}
 />
+
+<Reusables::Button
+  @text='Sign Up'
+  @variant='dark'
+  @onClick={{this.signup}}
+  @test='signup'
+  @type='button'
+/>

--- a/app/components/signup-steps/step-one.hbs
+++ b/app/components/signup-steps/step-one.hbs
@@ -47,3 +47,13 @@
   @onKeydown={{this.avoidNumbersAndSpaces}}
   @disabled={{true}}
 />
+
+<Reusables::Dropdown
+  @field='Select your role'
+  @name='role'
+  @placeHolder='Choose your role'
+  @required={{true}}
+  @value={{this.data.country}}
+  @options={{this.role}}
+  @onChange={{this.inputHandler}}
+/>

--- a/app/components/signup-steps/step-one.hbs
+++ b/app/components/signup-steps/step-one.hbs
@@ -51,7 +51,7 @@
 <Reusables::Dropdown
   @field='Select your role'
   @name='role'
-  @placeHolder='Choose your role'
+  @placeHolder='Choose Your Role'
   @required={{true}}
   @value={{this.data.role}}
   @options={{this.role}}

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -6,7 +6,7 @@ import { ROLE } from '../../constants/stepper-signup-data';
 import { JOIN_DEBOUNCE_TIME } from '../../constants/join';
 import { APPS } from '../../constants/urls';
 export default class SignupStepsStepOneComponent extends Component {
-  @tracked data = { firstname: '', lastname: '' };
+  @tracked data = { firstname: '', lastname: '', role: '' };
   @tracked isValid = true;
   @tracked username = '';
   role = ROLE;
@@ -15,7 +15,7 @@ export default class SignupStepsStepOneComponent extends Component {
     const passVal = () => {
       this.data = {
         ...this.data,
-        [e.target.name]: e.target.value.toLowerCase(),
+        [e.target.name]: e.target.value,
       };
       onChange(e.target.name, e.target.value.toLowerCase());
       if (this.data.firstname.trim() > '' && this.data.lastname.trim() > '') {
@@ -37,8 +37,8 @@ export default class SignupStepsStepOneComponent extends Component {
 
   @action async getUsername() {
     try {
-      const firstname = this.data.firstname;
-      const lastname = this.data.lastname;
+      const firstname = this.data.firstname.toLowerCase();
+      const lastname = this.data.lastname.toLowerCase();
       const response = await fetch(
         `${APPS.API_BACKEND}/users/username?firstname=${firstname}&lastname=${lastname}&dev=true`,
         {

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -2,12 +2,14 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
+import { ROLE } from '../../constants/stepper-signup-data';
 import { JOIN_DEBOUNCE_TIME } from '../../constants/join';
 import { APPS } from '../../constants/urls';
 export default class SignupStepsStepOneComponent extends Component {
   @tracked data = { firstname: '', lastname: '' };
   @tracked isValid = true;
   @tracked username = '';
+  role = ROLE;
   @action inputHandler(e) {
     const { onChange } = this.args;
     const passVal = () => {

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -28,6 +28,10 @@ export default class SignupStepsStepOneComponent extends Component {
     debounce(this.data, passVal, JOIN_DEBOUNCE_TIME);
   }
 
+  @action signup() {
+    console.log('');
+  }
+
   @action avoidNumbersAndSpaces(event) {
     var keyCode = event.keyCode || event.which;
     if (keyCode === 32 || (keyCode >= 48 && keyCode <= 57)) {

--- a/app/components/stepper-signup.js
+++ b/app/components/stepper-signup.js
@@ -20,10 +20,16 @@ export default class StepperSignupComponent extends Component {
     firstname: '',
     lastname: '',
     username: '',
+    role: {},
   };
 
   @action handleInputChange(key, value) {
-    set(this.signupDetails, key, value);
+    if (key === 'role') {
+      this.signupDetails.role = {};
+      set(this.signupDetails.role, value, true);
+    } else {
+      set(this.signupDetails, key, value);
+    }
   }
 
   @action setUsername(generateUsername) {

--- a/app/constants/stepper-signup-data.js
+++ b/app/constants/stepper-signup-data.js
@@ -1,0 +1,1 @@
+export const ROLE = ['Developer', 'Designer', 'Product Manager', 'Maven'];

--- a/app/styles/onboarding-card.module.css
+++ b/app/styles/onboarding-card.module.css
@@ -9,7 +9,7 @@
     position: relative;
     padding: 2rem;
     box-shadow: 0px 4px 10px -2px var(--color-blackshadow), 0px 6px 15px -2px var(--color-blackshadow2);
-    margin-top: 4rem;
+    margin-top:5rem;
 }
 .logo__github-rds {
     height: 5rem;

--- a/app/styles/stepper.module.css
+++ b/app/styles/stepper.module.css
@@ -93,6 +93,9 @@
   .user-input {
     width: 22rem;
   }
+  .select {
+    width: 23rem;
+  }
 }
 
 @media screen and (max-width: 768px) {
@@ -109,6 +112,9 @@
 
 @media (max-width: 480px) {
   .user-input {
+    width: 95%;
+  }
+  .select{
     width: 95%;
   }
 }

--- a/tests/integration/components/signup-steps/step-one-test.js
+++ b/tests/integration/components/signup-steps/step-one-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'website-www/tests/helpers';
-import { render, typeIn } from '@ember/test-helpers';
+import { render, typeIn, select, click } from '@ember/test-helpers';
 import { set } from '@ember/object';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -157,5 +157,49 @@ module('Integration | Component | signup-steps/step-one', function (hooks) {
     assert
       .dom('[data-test-button=generateUsername]')
       .hasProperty('disabled', false);
+  });
+
+  test('render select your role dropdown on signup details page and update signupdetails.role object ', async function (assert) {
+    assert.expect(13);
+    this.set('signupDetails', {
+      role: {},
+    });
+
+    this.set('handleInputChange', (selectRoleName, selectOptionValue) => {
+      this.name = selectRoleName;
+      this.value = selectOptionValue;
+      if (selectRoleName === 'role') {
+        this.signupDetails.role = {};
+        set(this.signupDetails.role, this.value, true);
+      }
+    });
+
+    await render(
+      hbs`<SignupSteps::StepOne @onChange={{this.handleInputChange}} />`
+    );
+
+    assert.dom('[data-test-dropdown]').hasClass('dropdown');
+
+    assert.dom('[data-test-required]').hasClass('required');
+
+    assert.dom('[data-test-dropdown-field]').hasClass('dropdown__field');
+    assert.dom('[data-test-dropdown-field]').hasAttribute('required');
+    assert.dom('[data-test-dropdown-field]').hasAttribute('name', 'role');
+    assert.dom('[data-test-dropdown-field]').hasAttribute('id', 'role');
+
+    assert.dom('[data-test-dropdown-option]').exists({ count: 4 });
+
+    assert.dom('[data-test-dropdown-default]').hasText('Choose Your Role');
+    assert.dom('[data-test-dropdown-default]').hasAttribute('disabled');
+    assert.dom('[data-test-dropdown-default]').hasAttribute('selected');
+
+    select('[data-test-dropdown-field]', 'Developer');
+    await click('[data-test-dropdown-option="Developer"]');
+    assert.dom('[data-test-dropdown-field]').hasValue('Developer');
+    assert.strictEqual(this.value, 'developer', 'changed correctly');
+    assert.true(
+      this.signupDetails.role.developer,
+      'signupDetails.role is updated'
+    );
   });
 });


### PR DESCRIPTION
### Issue  Closes #582

Parent Ticket: https://github.com/Real-Dev-Squad/todo-action-items/issues/178

### What is the change?

- Added a role selection feature on the signup-details page using a select tag, allowing users to choose a single role.
- The selected role is now passed to the signupDetails object in stepper-signup.js.
- Ensured that only one role is stored in signupDetails.role at a time.
- Added test render select your role dropdown on signup details page and update signupdetails.role object
- Feature under feature flag

### Is Development Tested?

- [x] Yes
- [ ] No

### Before / After Change Screenshots

Button part handle in this pr: https://github.com/Real-Dev-Squad/website-www/issues/651

https://github.com/Real-Dev-Squad/website-www/assets/107163260/ae462ed5-4301-46c7-9e75-9dd600d23774



