### PR TITLE
User Signup Form Validation and Toast Message

### DIFF
--- a/app/components/reusables/onboarding-input.hbs
+++ b/app/components/reusables/onboarding-input.hbs
@@ -7,7 +7,6 @@
   {{#if @required}}
     <span data-test-required={{@name}} class='required'>*</span>
   {{/if}}
-  {{! template-lint-disable no-down-event-binding  }}
   <input
     data-test-input-field={{@name}}
     name={{@name}}
@@ -19,7 +18,6 @@
     value={{@value}}
     disabled={{@disabled}}
     {{on 'input' @onInput}}
-    {{on 'keydown' @onKeydown}}
   />
   {{#if @hasButtonInsideInput}}
     <Reusables::Button

--- a/app/components/reusables/onboarding-input.hbs
+++ b/app/components/reusables/onboarding-input.hbs
@@ -7,6 +7,7 @@
   {{#if @required}}
     <span data-test-required={{@name}} class='required'>*</span>
   {{/if}}
+  {{! template-lint-disable no-down-event-binding  }}
   <input
     data-test-input-field={{@name}}
     name={{@name}}

--- a/app/components/signup-steps/step-one.hbs
+++ b/app/components/signup-steps/step-one.hbs
@@ -16,10 +16,14 @@
   @required={{true}}
   @value={{this.data.firstname}}
   @onInput={{this.inputHandler}}
-  @onKeydown={{this.avoidNumbersAndSpaces}}
   @hasButtonInsideInput={{false}}
   @disabled={{false}}
 />
+
+{{#if this.errorMessage.firstname}}
+  <div class='error__message'>{{this.errorMessage.firstname}}</div>
+{{/if}}
+
 <Reusables::OnboardingInput
   @field='Last Name'
   @name='lastname'
@@ -28,10 +32,13 @@
   @required={{true}}
   @value={{this.data.lastname}}
   @onInput={{this.inputHandler}}
-  @onKeydown={{this.avoidNumbersAndSpaces}}
   @hasButtonInsideInput={{false}}
   @disabled={{false}}
 />
+
+{{#if this.errorMessage.lastname}}
+  <div class='error__message'>{{this.errorMessage.lastname}}</div>
+{{/if}}
 
 <Reusables::OnboardingInput
   @field='Username'
@@ -44,7 +51,6 @@
   @classDisableInput='input-disable'
   @onClickGetUsername={{this.getUsername}}
   @onInput={{this.inputHandler}}
-  @onKeydown={{this.avoidNumbersAndSpaces}}
   @disabled={{true}}
 />
 

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -8,6 +8,7 @@ import { APPS } from '../../constants/urls';
 export default class SignupStepsStepOneComponent extends Component {
   @tracked data = { firstname: '', lastname: '', role: '' };
   @tracked username = '';
+  @tracked isValid = true;
   role = ROLE;
   @tracked errorMessage = {
     firstname: '',
@@ -42,6 +43,16 @@ export default class SignupStepsStepOneComponent extends Component {
             ? `No spaces, numbers, or special characters allowed.`
             : '',
         };
+      }
+      if (
+        this.data.firstname.trim() > '' &&
+        this.data.lastname.trim() > '' &&
+        this.errorMessage.firstname === '' &&
+        this.errorMessage.lastname === ''
+      ) {
+        this.isValid = false;
+      } else {
+        this.isValid = true;
       }
     };
 

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -19,8 +19,7 @@ export default class SignupStepsStepOneComponent extends Component {
   };
 
   nameValidator(name) {
-    const pattern =
-      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    const pattern = /^[a-zA-Z]{1,20}$/;
 
     if (pattern.test(name)) {
       return { isValid: false };

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -7,9 +7,24 @@ import { JOIN_DEBOUNCE_TIME } from '../../constants/join';
 import { APPS } from '../../constants/urls';
 export default class SignupStepsStepOneComponent extends Component {
   @tracked data = { firstname: '', lastname: '', role: '' };
-  @tracked isValid = true;
   @tracked username = '';
   role = ROLE;
+  @tracked errorMessage = {
+    firstname: '',
+    lastname: '',
+  };
+
+  nameValidator(name) {
+    const pattern =
+      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+
+    if (pattern.test(name)) {
+      return { isValid: false };
+    } else {
+      return { isValid: true };
+    }
+  }
+
   @action inputHandler(e) {
     const { onChange } = this.args;
     const passVal = () => {
@@ -18,10 +33,15 @@ export default class SignupStepsStepOneComponent extends Component {
         [e.target.name]: e.target.value,
       };
       onChange(e.target.name, e.target.value.toLowerCase());
-      if (this.data.firstname.trim() > '' && this.data.lastname.trim() > '') {
-        this.isValid = false;
-      } else {
-        this.isValid = true;
+      const field = e.target.name;
+      if (field === 'firstname' || field === 'lastname') {
+        const { isValid } = this.nameValidator(e.target.value);
+        this.errorMessage = {
+          ...this.errorMessage,
+          [field]: isValid
+            ? `No spaces, numbers, or special characters allowed,and max 20 characters.`
+            : '',
+        };
       }
     };
 

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -2,10 +2,13 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import { ROLE } from '../../constants/stepper-signup-data';
 import { JOIN_DEBOUNCE_TIME } from '../../constants/join';
 import { APPS } from '../../constants/urls';
+import { toastNotificationTimeoutOptions } from '../../constants/toast-notification';
 export default class SignupStepsStepOneComponent extends Component {
+  @service toast;
   @tracked data = { firstname: '', lastname: '', role: '' };
   @tracked username = '';
   @tracked isValid = true;
@@ -85,8 +88,16 @@ export default class SignupStepsStepOneComponent extends Component {
         }
       );
       const data = await response.json();
-      this.username = data.username;
-      this.args.setUsername(this.username);
+      if (response.status === 200) {
+        this.username = data.username;
+        this.args.setUsername(this.username);
+      } else if (response.status === 401) {
+        this.toast.error(
+          'You are not logged in. Please login to continue.',
+          '',
+          toastNotificationTimeoutOptions
+        );
+      }
     } catch (err) {
       console.log('Error: ', err);
     }

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -39,7 +39,7 @@ export default class SignupStepsStepOneComponent extends Component {
         this.errorMessage = {
           ...this.errorMessage,
           [field]: isValid
-            ? `No spaces, numbers, or special characters allowed,and max 20 characters.`
+            ? `No spaces, numbers, or special characters allowed.`
             : '',
         };
       }

--- a/app/components/signup-steps/step-one.js
+++ b/app/components/signup-steps/step-one.js
@@ -92,13 +92,13 @@ export default class SignupStepsStepOneComponent extends Component {
         this.args.setUsername(this.username);
       } else if (response.status === 401) {
         this.toast.error(
-          'You are not logged in. Please login to continue.',
+          'Please login to continue.',
           '',
           toastNotificationTimeoutOptions
         );
       }
     } catch (err) {
-      console.log('Error: ', err);
+      console.log('Error: ', 'Something went wrong');
     }
   }
 }

--- a/app/constants/toast-notification.js
+++ b/app/constants/toast-notification.js
@@ -1,0 +1,5 @@
+export const toastNotificationTimeoutOptions = {
+  timeOut: '0',
+  extendedTimeOut: '0',
+  preventDuplicates: false,
+};

--- a/app/styles/onboarding-card.module.css
+++ b/app/styles/onboarding-card.module.css
@@ -31,7 +31,8 @@
     position: absolute;
     transform: translateX(-50%);
     left: 50%;
-    top: -15%;
+    top: 0;
+    transform: translateX(-50%) translateY(-50%);
 }
 
 .logos-container__rds {

--- a/tests/integration/components/signup-steps/step-one-test.js
+++ b/tests/integration/components/signup-steps/step-one-test.js
@@ -138,7 +138,7 @@ module('Integration | Component | signup-steps/step-one', function (hooks) {
       .hasProperty('disabled', true);
   });
 
-  test('generateUsername button is enabled when firstname and lastname input fields are not empty', async function (assert) {
+  test('generateUsername button is enabled when firstname and lastname input fields are not empty and valid input', async function (assert) {
     assert.expect(1);
     this.set('onInput', (e) => {
       this.value = e.target.value;
@@ -201,5 +201,22 @@ module('Integration | Component | signup-steps/step-one', function (hooks) {
       this.signupDetails.role.developer,
       'signupDetails.role is updated'
     );
+  });
+
+  test('It display error message and disable the button for invalid input', async function (assert) {
+    assert.expect(2);
+    this.set('handleInputChange', (inputName, inputValue) => {
+      this.name = inputName;
+      this.value = inputValue;
+    });
+    await render(
+      hbs`<SignupSteps::StepOne  @onChange={{this.handleInputChange}}/ />`
+    );
+    await typeIn('[data-test-input-field=firstname]', 'shubham_1');
+    await typeIn('[data-test-input-field=lastname]', 'sigdar@');
+    assert.dom('.error__message').exists();
+    assert
+      .dom('[data-test-button=generateUsername]')
+      .hasProperty('disabled', true);
   });
 });


### PR DESCRIPTION
### Issue Closes #654 

Parent ticket: https://github.com/Real-Dev-Squad/todo-action-items/issues/178

### What is the change?

- Allow user to input anything in "firstname" and "lastname" input field

- If the input in the "firstname" or "lastname" fields violates certain criteria i.e. input not contain spaces, non-alphabetical characters, numbers, more than 20 character, an error message should be displayed below the respective input field ("firstname" and "lastname") and generateusername button will disable
-  If the input in both the "firstname" and "lastname" fields meet the criteria, a button will enable and a username should be generated.
- When the "sign-in-with-github" session is logged out, and the "generateUsername" button is clicked, A toast message should be displayed.
- Feature under feature flag

### Is Development Tested?

- [X] Yes
- [ ] No

### After Change Video

https://github.com/Real-Dev-Squad/website-www/assets/107163260/a21b8dda-44e4-4d54-b322-9f1699c71ad6


Test video:

https://github.com/Real-Dev-Squad/website-www/assets/107163260/b7add596-f1b9-4e9e-93b7-f87fe7974856



