### PR TITLE
[Live Site]: Remove kick out option for host

### DIFF
--- a/app/components/live-participants.hbs
+++ b/app/components/live-participants.hbs
@@ -31,19 +31,21 @@
                     <span></span>
                   </div>
                 {{else}}
-                  <button
-                    type='button'
-                    class='user__btn'
-                    {{on 'click' (fn @openKickoutModal peer)}}
-                  >
-                    <IconifyIcon
-                      data-test-icon='remove'
-                      @icon='material-symbols:person-remove'
-                      width='36'
-                      height='36'
-                      color='red'
-                    />
-                  </button>
+                  {{#if (not-eq peer.roleName this.ROLES.host)}}
+                    <button
+                      type='button'
+                      class='user__btn'
+                      {{on 'click' (fn @openKickoutModal peer)}}
+                    >
+                      <IconifyIcon
+                        data-test-icon='remove'
+                        @icon='material-symbols:person-remove'
+                        width='36'
+                        height='36'
+                        color='red'
+                      />
+                    </button>
+                  {{/if}}
                 {{/if}}
 
               {{/if}}

--- a/tests/integration/components/live-participants-test.js
+++ b/tests/integration/components/live-participants-test.js
@@ -157,4 +157,23 @@ module('Integration | Component | live-participants', function (hooks) {
     assert.dom('[data-test-sidebar-body-role-guest]').hasText('Guest (2)');
     assert.dom('[data-test-sidebar-user="3"]').hasText('Guest2');
   });
+
+  test('kickout option should not be there for host', async function (assert) {
+    this.setProperties({
+      peers: hostPeer,
+      profilePic: 'profilepicurl',
+      isKickoutModalOpen: false,
+    });
+    this.set('openKickoutModal', () => {});
+
+    await render(hbs`<LiveParticipants
+      @user='Hosts'
+      @role='host'
+      @peers={{this.peers}}
+      @minimumParticipants="host"
+      @openKickoutModal={{this.openKickoutModal}}
+    />`);
+
+    assert.dom('[data-test-icon="remove"]').doesNotExist();
+  });
 });


### PR DESCRIPTION
### Remove kick-out for the host

##### Closes #684 

### What is the change?
- Remove the kick-out option for the host as the host cannot kick out hosts in the event.

### Is Development Tested?

- [x] Yes
- [ ] No

### Before / After Change Screenshots

https://github.com/Real-Dev-Squad/website-www/assets/40385118/45fa7e75-b843-4b41-bbd1-cd1b650c7d9f

Moderator:
![image](https://github.com/Real-Dev-Squad/website-www/assets/40385118/6bbd08af-1323-45d9-9722-42697fc82a7f)

