### PR TITLE
[Ember-Migration] Footer Enhancement

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -1,21 +1,23 @@
 {{#if this.isDevMode}}
   <footer aria-label='footer under dev feature flag' class='footer--dev'>
-    <Events />
-    <h3 data-test-footer-info class='footer__info'>
-      To know how this page is developed, join our Discord channel by contacting
-      one of
-      <a
-        data-test-footer-info-members-link
-        href={{this.MEMBERS_URL}}
-        class='footer__info__link'
-      >our existing members</a>
-      or our
-      <a
-        data-test-footer-info-faq-link
-        href={{this.FAQ_URL}}
-        class='footer__info__link'
-      > FAQ section</a>.
-    </h3>
+    {{#if this.isHome}}
+      <Events />
+      <h3 data-test-footer-info class='footer__info'>
+        To know how this page is developed, join our Discord channel by
+        contacting one of
+        <a
+          data-test-footer-info-members-link
+          href={{this.MEMBERS_URL}}
+          class='footer__info__link'
+        >our existing members</a>
+        or our
+        <a
+          data-test-footer-info-faq-link
+          href={{this.FAQ_URL}}
+          class='footer__info__link'
+        > FAQ section</a>.
+      </h3>
+    {{/if}}
     <p data-test-footer-repo-text-dev class='footer__repo--dev'>The contents of
       the website are deployed from this
       <a

--- a/app/components/footer.js
+++ b/app/components/footer.js
@@ -3,15 +3,20 @@ import { ABOUT, APPS } from '../constants/urls';
 import { APPS_PROPERTIES, ABOUT_PROPERTIES } from '../constants/footer-data';
 import { SOCIAL_LINK_PROPERTIES } from '../constants/social-data';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class FooterComponent extends Component {
   @service featureFlag;
+  @service router;
+
   REPOSITORY_URL = ABOUT.REPOSITORY;
   APPS_PROPERTIES = APPS_PROPERTIES;
   ABOUT_PROPERTIES = ABOUT_PROPERTIES;
   SOCIAL_LINK_PROPERTIES = SOCIAL_LINK_PROPERTIES;
   MEMBERS_URL = APPS.MEMBERS;
   FAQ_URL = ABOUT.FAQ;
+
+  @tracked isHome = this.router.currentRoute.name === 'index';
 
   get isDevMode() {
     return this.featureFlag.isDevMode;

--- a/tests/acceptance/render-footer-dynamically-test.js
+++ b/tests/acceptance/render-footer-dynamically-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website-www/tests/helpers';
+
+module('Acceptance | render footer dynamically', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Should render all parts of footer when visting /?dev=true', async function (assert) {
+    await visit('/?dev=true');
+
+    assert.strictEqual(currentURL(), '/?dev=true');
+
+    assert.dom('[data-test-events-section]').exists();
+    assert.dom('[data-test-footer-info]').exists();
+    assert.dom('[data-test-footer-repo-text-dev]').exists();
+  });
+
+  test('Should render only repo details in footer when visiting /live?dev=true', async function (assert) {
+    await visit('/live?dev=true');
+
+    assert.strictEqual(currentURL(), '/live?dev=true');
+
+    assert.dom('[data-test-events-section]').doesNotExist();
+    assert.dom('[data-test-footer-info]').doesNotExist();
+    assert.dom('[data-test-footer-repo-text-dev]').exists();
+  });
+
+  test('Should render only repo details in footer when visiting /join?dev=true', async function (assert) {
+    await visit('/join?dev=true');
+
+    assert.strictEqual(currentURL(), '/join?dev=true');
+
+    assert.dom('[data-test-events-section]').doesNotExist();
+    assert.dom('[data-test-footer-info]').doesNotExist();
+    assert.dom('[data-test-footer-repo-text-dev]').exists();
+  });
+});


### PR DESCRIPTION
closes #722 

### Issue
- #722 

### What is the change?
- This change dynamically renders footer depending on route. Only `The contents of this website are deployed from this open sourced repo` part is visible in all pages and in home route events and other parts of footer is visible.

### Frontend Changes
- [x] Yes
- [ ] No

### Backend Changes
- [ ] Yes
- [x] No

### Feature Flag
- [x] Yes
- [ ] No

### Is Development Tested?

- [x] Yes
- [ ] No

https://github.com/Real-Dev-Squad/website-www/assets/87164140/388022d0-a8dd-4051-8daf-9c233a15357d


### Visual of changes

https://github.com/Real-Dev-Squad/website-www/assets/87164140/e1a08462-c727-41e2-a013-4b23d5df3306

