### PR TITLE
fix: screen share text update issue

### DIFF
--- a/app/services/live.js
+++ b/app/services/live.js
@@ -404,10 +404,11 @@ export default class LiveService extends Service {
     const presenterTrackId = peers?.find((p) => p.roleName === ROLES.host)
       ?.auxiliaryTracks[0];
     if (presenterTrackId) {
-      this.isScreenShareOn = true;
       await this.hmsActions.attachVideo(presenterTrackId, this.videoEl);
+      this.isScreenShareOn = true;
     } else {
       await this.hmsActions.detachVideo(presenterTrackId, this.videoEl);
+      this.isScreenShareOn = false;
     }
   }
 


### PR DESCRIPTION
### Issue #736 

##### Example : Closes #736 

### What is the change?
In this PR I have fixed the issue screen share text not updating when screen share stops for joined peers.


##### Example :
- Updated the tracked variable so that rendering happens accordingly.

Date: 6-11-2023

Developer Name: Satyam Bajpai

PR Number(s):- #737

Issue Ticket Number:- #736 

Backend changes
- [ ] Yes
- [x] No

Frontend Changes
- [x] Yes
- [ ] No

Is Under Feature Flag 
- [x] Yes
- [ ] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Deployment notes
Any special instructions for the deployment (N/A)

Tested in staging
- [ ] Yes
- [x] No

### Is Development Tested?
- [x] Yes
- [ ] No

### Before / After Change Screenshots

https://github.com/Real-Dev-Squad/website-www/assets/85296770/74f1c929-09c7-48ed-8a7d-8388823e1666



**Note :**
What to delete and what not to

- Keep the headings and answer the questions.
- Delete the examples
- Delete the description below headings `What is the change?` & `Before/After Screenshots`
