### PR TITLE
Hide home events links

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,8 +1,35 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+/package-lock.json
+# compiled output
+/dist/
+/declarations/
+
+# dependencies
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.eslintcache
+/coverage/
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/
+
+# vs-code config
+/.vscode/
+
 # unconventional files
 /blueprints/*/files/
 
-# compiled output
-/dist/
-
-# addons
-/.node_modules.ember-try/

--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -1,28 +1,30 @@
-<footer aria-label='footer' class='footer'>
+<footer aria-label="footer" class="footer">
   {{#if this.isHome}}
-    <Events />
-    <h3 data-test-footer-info class='footer__info'>
-      To know how this page is developed, join our Discord channel by
-      contacting one of
+    {{! Events section is to be migrated, will use it once its done,
+     track it here https://github.com/Real-Dev-Squad/website-www/issues/787 }}
+    {{! <Events /> }}
+    <h3 data-test-footer-info class="footer__info">
+      To know how this page is developed, join our Discord channel by contacting
+      one of
       <a
         data-test-footer-info-members-link
         href={{this.MEMBERS_URL}}
-        class='footer__info__link'
+        class="footer__info__link"
       >our existing members</a>
       or our
       <a
         data-test-footer-info-faq-link
         href={{this.FAQ_URL}}
-        class='footer__info__link'
+        class="footer__info__link"
       > FAQ section</a>.
     </h3>
   {{/if}}
-  <p data-test-footer-repo-text class='footer__repo'>The contents of
-    the website are deployed from this
+  <p data-test-footer-repo-text class="footer__repo">The contents of the website
+    are deployed from this
     <a
       data-test-footer-repo-link
       href={{this.REPOSITORY_URL}}
-      class='footer__repo__link'
+      class="footer__repo__link"
     >open sourced repo</a>
   </p>
 </footer>

--- a/tests/acceptance/render-footer-dynamically-test.js
+++ b/tests/acceptance/render-footer-dynamically-test.js
@@ -10,7 +10,11 @@ module('Acceptance | render footer dynamically', function (hooks) {
 
     assert.strictEqual(currentURL(), '/');
 
-    assert.dom('[data-test-events-section]').exists();
+    /*
+      Events section is to be migrated, will use it once its done,
+      track it here https://github.com/Real-Dev-Squad/website-www/issues/787
+    */
+    assert.dom('[data-test-events-section]').doesNotExist();
     assert.dom('[data-test-footer-info]').exists();
     assert.dom('[data-test-footer-repo-text]').exists();
   });

--- a/tests/integration/components/events-test.js
+++ b/tests/integration/components/events-test.js
@@ -6,8 +6,12 @@ import { EVENTS_CATEGORIES } from '../../constants/events-data';
 
 module('Integration | Component | events', function (hooks) {
   setupRenderingTest(hooks);
-
-  test('events renders', async function (assert) {
+  /*
+    Skipping tests
+    Events section is to be migrated, will use it once its done,
+    track it here https://github.com/Real-Dev-Squad/website-www/issues/787
+  */
+  test.skip('events renders', async function (assert) {
     await render(hbs`<Events />`);
 
     assert.dom('[data-test-events-section]').exists();

--- a/tests/integration/components/footer-test.js
+++ b/tests/integration/components/footer-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'website-www/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
-import { EVENTS_CATEGORIES } from '../../constants/events-data';
+// import { EVENTS_CATEGORIES } from '../../constants/events-data';
 
 module('Integration | Component | footer', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,19 +17,23 @@ module('Integration | Component | footer', function (hooks) {
   });
 
   test('footer renders', async function (assert) {
-    assert.expect(16);
+    assert.expect(6);
 
     this.set('isHome', true);
 
     await render(hbs`<Footer @isHome={{this.isHome}} />`);
 
-    assert.dom('[data-test-events-section]').exists();
-    for (const eventCategory in EVENTS_CATEGORIES) {
-      assert.dom(`[data-test-events-category="${eventCategory}"]`).exists();
-      EVENTS_CATEGORIES[eventCategory].forEach((event) => {
-        assert.dom(`[data-test-events-link="${event.name}"]`).exists();
-      });
-    }
+    assert.dom('[data-test-events-section]').doesNotExist();
+    /*
+     Events section is to be migrated, will use it once its done,
+     track it here https://github.com/Real-Dev-Squad/website-www/issues/787
+     */
+    // for (const eventCategory in EVENTS_CATEGORIES) {
+    //   assert.dom(`[data-test-events-category="${eventCategory}"]`).exists();
+    //   EVENTS_CATEGORIES[eventCategory].forEach((event) => {
+    //     assert.dom(`[data-test-events-link="${event.name}"]`).exists();
+    //   });
+    // }
     assert.dom('[data-test-footer-info]').exists();
     assert.dom('[data-test-footer-info-members-link]').exists();
     assert.dom('[data-test-footer-info-faq-link]').exists();


### PR DESCRIPTION
### Issue

##### Example : Closes #<issue_number>

### What is the change?

Hides events links, will show them after migration to ember is done

### Is Development Tested?

- [x] Yes
- [ ] No

### Before / After Change Screenshots

### BEFORE
<img width="1151" alt="image" src="https://github.com/Real-Dev-Squad/website-www/assets/34452139/b3345647-1cc4-4708-a5ae-b902b700abc0">

### After 
<img width="913" alt="image" src="https://github.com/Real-Dev-Squad/website-www/assets/34452139/88170f59-841a-4e3c-8882-cef77ae03e9e">
