### PR TITLE
fix: modal opening issue even if host doesn't asks questions

### DIFF
--- a/app/controllers/live.js
+++ b/app/controllers/live.js
@@ -302,7 +302,7 @@ export default class LiveController extends Controller {
 
     event.onmessage = async (event) => {
       const parsedQuestion = JSON.parse(event.data);
-      const question = parsedQuestion || {};
+      const question = parsedQuestion;
 
       const isQuestionChanged = question?.id !== this.survey.recentQuestion?.id;
 


### PR DESCRIPTION
Date: `24-01-2024`

Developer Name: `Satyam Bajpai`

---

## Issue Ticket Number:-

- #849 

## Description:

Currently in the word cloud question answer feature a modal appears automatically even if the host hasn't asked a question. The modal appears with a empty question at some small intervals which is not a good UI/UX, and it is not supposed to work like that.

Is Under Feature Flag

- [x] Yes
- [ ] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
