### PR TITLE
fix(895)!: temp fixes join page for archived users

### DIFF
--- a/app/components/stepper.js
+++ b/app/components/stepper.js
@@ -54,6 +54,8 @@ export default class StepperComponent extends Component {
       localStorage.setItem('first_name', this.login.userData.first_name);
       localStorage.setItem('last_name', this.login.userData.last_name);
       this.incrementStep();
+    } else {
+      alert('You must be logged in to continue');
     }
   }
 

--- a/app/templates/join.hbs
+++ b/app/templates/join.hbs
@@ -5,7 +5,8 @@
       <Fa-Icon @size='2x' @icon='circle-notch' @spin={{true}} />
     </div>
   {{else}}
-    {{#if this.login.userData.roles.archived}}
+    {{!-- Quick hack for unblocking everyone - https://github.com/Real-Dev-Squad/website-www/issues/895 --}}
+    {{#if false}} {{!-- {{#if this.login.userData.roles.archived}} --}}
       <OnboardingCard>
         <h3 data-test-archived-heading class='archived__heading'>Archived User</h3>
         <p data-test-archived-message class='archived__message'>


### PR DESCRIPTION
Date: Aug 16, 2024

Developer Name: Ankush Dharkar

---

## Issue Ticket Number:-

- #895

## Description:

Temporarily unblocks archived users to submit the /join form. Cron job seems to be marking users not in discord as archived and blocking them

Is Under Feature Flag

- [ ] Yes
- [x] No - This is a hotfix and needs to be available on prod

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [x] Yes - Unintended side-effects may occur from /join APIs now working for archived users. Risk: Minor (since backend should authorize correctly)
- [ ] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<img width="765" alt="Google Chrome 2024-08-16 16 32 26" src="https://github.com/user-attachments/assets/95b04975-fd14-4a7f-b8d6-b9421d652bf4">
