### PR TITLE
README updation: use yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A short introduction of this app could easily go here.
 You will need the following things properly installed on your computer.
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) (with npm)
+- [Node.js](https://nodejs.org/) (with yarn)
 - [Ember CLI](https://cli.emberjs.com/release/)
 - [Google Chrome](https://google.com/chrome/)
 
@@ -16,7 +16,7 @@ You will need the following things properly installed on your computer.
 
 - `git clone <repository-url>` this repository
 - `cd website-www`
-- `npm install`
+- `yarn install`
 
 ## Running / Development
 


### PR DESCRIPTION
Date: `20/08/2024`

Developer Name: `Akanksha Dharkar`

---

## Issue Ticket Number:-

Not applicable

## Description:

While setting up the repo, I realised that the readme says to use `npm i` but the file in the repo is yarn.lock

Is Under Feature Flag

- [ ] Yes
- [x] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [ ] Yes
- [x] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
Not required here