### PR TITLE
Fix users routing on /intro 

### DIFF
--- a/app/routes/intro.js
+++ b/app/routes/intro.js
@@ -29,6 +29,11 @@ export default class IntroRoute extends Route {
       });
       userData = await userResponse.json();
 
+      if (!userData?.roles?.super_user) {
+        this.router.transitionTo('/join');
+        return;
+      }
+
       const response = await fetch(APPLICATION_URL(userId), {
         credentials: 'include',
       });

--- a/app/routes/intro.js
+++ b/app/routes/intro.js
@@ -29,7 +29,7 @@ export default class IntroRoute extends Route {
       });
       userData = await userResponse.json();
 
-      if (!userData?.roles?.super_user) {
+      if (!userData.roles.super_user) {
         this.router.transitionTo('/join');
         return;
       }


### PR DESCRIPTION
## Issue Ticket Number:-

- closes #920 

## Description:

When normal users visit /intro route then they will redirect to /join to check their application status

Is Under Feature Flag

- [ ] Yes
- [x] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
