### PR TITLE
fix status card rendering based on user application

### DIFF
--- a/app/controllers/join.js
+++ b/app/controllers/join.js
@@ -9,15 +9,25 @@ export default class JoinController extends Controller {
   @service router;
   @service login;
   @service featureFlag;
+  @service onboarding;
   @tracked chaincode = 'Generate chaincode';
   @tracked isChaincodeClicked = false;
   @tracked isLoading = false;
+
   ANKUSH_TWITTER = ANKUSH_TWITTER;
 
   queryParams = ['step', 'dev'];
 
   get isDevMode() {
     return this.featureFlag.isDevMode;
+  }
+
+  get applicationData() {
+    return this.onboarding.applicationData;
+  }
+
+  get loading() {
+    return this.login.isLoading || this.onboarding.loadingApplicationData;
   }
 
   @action async handleGenerateChaincode(e) {

--- a/app/services/onboarding.js
+++ b/app/services/onboarding.js
@@ -9,6 +9,7 @@ export default class OnboardingService extends Service {
   @service store;
   @service toast;
   @tracked applicationData;
+  @tracked loadingApplicationData = true;
 
   constructor() {
     super(...arguments);
@@ -126,6 +127,8 @@ export default class OnboardingService extends Service {
       const applicationData = await applicationResponse.json();
 
       this.applicationData = applicationData?.applications?.[0];
+
+      this.loadingApplicationData = false;
     } catch (err) {
       console.error('Error: ', err);
       this.toast.error('Some error occured', 'Error ocurred!', TOAST_OPTIONS);

--- a/app/templates/join.hbs
+++ b/app/templates/join.hbs
@@ -1,6 +1,6 @@
 {{page-title 'Join'}}
 <section class='join__container'>
-  {{#if this.login.isLoading}}
+  {{#if this.loading}}
     <div data-test-loading class='intro__loading'>
       <Fa-Icon @size='2x' @icon='circle-notch' @spin={{true}} />
     </div>
@@ -29,15 +29,23 @@
         </div>
       </OnboardingCard>
     {{else}}
-      {{#if this.isDevMode}}
-        <StepperSignup
-          @chaincode={{this.chaincode}}
-          @isChaincodeClicked={{this.isChaincodeClicked}}
-          @isLoading={{this.isLoading}}
-          @handleGenerateChaincode={{this.handleGenerateChaincode}}
+      {{#if this.applicationData}}
+        <JoinSteps::StatusCard 
+          @status={{this.applicationData.status}}
+          @feedback={{this.applicationData.feedback}}
+          @joinDiscord={{this.joinDiscordHandler}}
         />
       {{else}}
-        <Stepper />
+        {{#if this.isDevMode}}
+          <StepperSignup
+            @chaincode={{this.chaincode}}
+            @isChaincodeClicked={{this.isChaincodeClicked}}
+            @isLoading={{this.isLoading}}
+            @handleGenerateChaincode={{this.handleGenerateChaincode}}
+          />
+        {{else}}
+          <Stepper />
+        {{/if}}
       {{/if}}
     {{/if}}
   {{/if}}


### PR DESCRIPTION
## Issue Ticket Number:-

- closes #911 

## Description:

 navigating to the /join route, it fetch the users application details if exist redirect them to the status card of the application otherwise let them filled the application

Is Under Feature Flag

- [ ] Yes
- [x] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
