### PR TITLE
Fix identity page reload

### DIFF
--- a/app/components/identity/reload.hbs
+++ b/app/components/identity/reload.hbs
@@ -1,11 +1,6 @@
 <div class='identity-box-heading' data-test-reload-heading>Status Pending</div>
 <div class='identity-box-desc' data-test-reload-desc>Reload to complete and
-  verify the link between Profile Service and RealDevSquad Service.</div>
+  verify the link between Profile Service and RealDevSquad Service. testing</div>
 <button
-  class='identity-box-button'
-  data-test-blocked-button 
-  type="button" 
-  {{on "click" (fn this.setState "step1")}}
->
-  Retry
-</button>
+  class='identity-box-button' type="button" {{on 'click' this.handleReload}}
+>Reload</button>

--- a/app/components/identity/reload.hbs
+++ b/app/components/identity/reload.hbs
@@ -1,6 +1,6 @@
 <div class='identity-box-heading' data-test-reload-heading>Status Pending</div>
 <div class='identity-box-desc' data-test-reload-desc>Reload to complete and
-  verify the link between Profile Service and RealDevSquad Service. testing</div>
+  verify the link between Profile Service and RealDevSquad Service.</div>
 <button
   class='identity-box-button' type="button" {{on 'click' this.handleReload}}
 >Reload</button>

--- a/app/controllers/identity.js
+++ b/app/controllers/identity.js
@@ -8,29 +8,7 @@ export default class IdentityController extends Controller {
 
   @tracked userData = null;
   @tracked profileURL = null;
-
-  constructor() {
-    super(...arguments);
-    this.userData = this.login.userData;
-    this.state = this.initialState;
-    this.profileURL = this.userData?.profileURL;
-  }
-
-  get initialState() {
-    const profileStatus = this.model?.profileStatus;
-    switch (profileStatus) {
-      case 'PENDING':
-        return 'reload';
-      case 'VERIFIED':
-        return 'verified';
-      case 'BLOCKED':
-        return 'blocked';
-      default:
-        return 'getStarted';
-    }
-  }
-
-  @tracked state = this.initialState;
+  @tracked state = 'getStarted';
 
   @action
   setState(newState) {

--- a/app/routes/identity.js
+++ b/app/routes/identity.js
@@ -40,17 +40,36 @@ export default class IdentityRoute extends Route {
       }
 
       const data = await response.json();
-
       if (!data?.roles?.in_discord) {
         this.router.transitionTo('index');
         return null;
       }
-
       return data;
     } catch (error) {
       console.error('Error fetching user data:', error);
       this.router.transitionTo('index');
       return null;
+    }
+  }
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    controller.userData = this.login.userData;
+    controller.profileURL = controller.userData?.profileURL;
+
+    const profileStatus = model?.profileStatus;
+    switch (profileStatus) {
+      case 'PENDING':
+        controller.state = 'reload';
+        break;
+      case 'VERIFIED':
+        controller.state = 'verified';
+        break;
+      case 'BLOCKED':
+        controller.state = 'blocked';
+        break;
+      default:
+        controller.state = 'getStarted';
     }
   }
 }

--- a/app/styles/identity.module.css
+++ b/app/styles/identity.module.css
@@ -118,6 +118,10 @@
   margin-top: 20px;
 }
 
+.identity-box-button:hover {
+  cursor: pointer;
+}
+
 @media (width <= 460px) {
   .identity-box-button {
     font-size: 12px;
@@ -228,6 +232,10 @@
   position: absolute;
   right: 4%;
   bottom: 8%;
+}
+
+.identity-next-button:hover {
+  cursor: pointer;
 }
 
 .identity-box-input {

--- a/app/templates/identity.hbs
+++ b/app/templates/identity.hbs
@@ -23,23 +23,23 @@
     </div>
   {{/if}}
 
-  <div class="identity-box">
-    {{#if (eq this.state "getStarted")}}
+  <div class='identity-box'>
+    {{#if (eq this.state 'getStarted')}}
       <Identity::GetStarted @setState={{this.setState}} />
-    {{else if (eq this.state "step1")}}
+    {{else if (eq this.state 'step1')}}
       <Identity::Step1 @setState={{this.setState}} />
-    {{else if (eq this.state "step2")}}
+    {{else if (eq this.state 'step2')}}
       <Identity::Step2
         @setState={{this.setState}}
-        @profileURL={{this.profileURL}}
+        @profileURL={{@model.profileURL}}
       />
-    {{else if (eq this.state "step3")}}
+    {{else if (eq this.state 'step3')}}
       <Identity::Step3 @setState={{this.setState}} />
-    {{else if (eq this.state "reload")}}
+    {{else if (eq this.state 'reload')}}
       <Identity::Reload />
-    {{else if (eq this.state "verified")}}
+    {{else if (eq this.state 'verified')}}
       <Identity::Verified />
-    {{else if (eq this.state "blocked")}}
+    {{else if (eq this.state 'blocked')}}
       <Identity::Blocked @setState={{this.setState}} />
     {{/if}}
   </div>

--- a/tests/unit/controllers/identity-test.js
+++ b/tests/unit/controllers/identity-test.js
@@ -4,9 +4,13 @@ import { setupTest } from 'website-www/tests/helpers';
 module('Unit | Controller | index', function (hooks) {
   setupTest(hooks);
 
-  test('it initializes userData and profileURL correctly', function (assert) {
-    const controller = this.owner.lookup('controller:identity');
+  let controller;
 
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:identity');
+  });
+
+  test('it initializes userData and profileURL correctly', function (assert) {
     assert.strictEqual(
       controller.userData,
       null,
@@ -20,8 +24,6 @@ module('Unit | Controller | index', function (hooks) {
   });
 
   test('it checks if setState updates the state correctly', function (assert) {
-    const controller = this.owner.lookup('controller:identity');
-
     controller.setState('getStarted');
 
     assert.strictEqual(
@@ -30,9 +32,8 @@ module('Unit | Controller | index', function (hooks) {
       'state is updated correctly',
     );
   });
-  test('action setState updates the state correctly', function (assert) {
-    const controller = this.owner.lookup('controller:identity');
 
+  test('action setState updates the state correctly', function (assert) {
     controller.setState('not-linked');
 
     assert.strictEqual(

--- a/tests/unit/controllers/identity-test.js
+++ b/tests/unit/controllers/identity-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'website-www/tests/helpers';
+
+module('Unit | Controller | index', function (hooks) {
+  setupTest(hooks);
+
+  test('it initializes userData and profileURL correctly', function (assert) {
+    const controller = this.owner.lookup('controller:identity');
+
+    assert.strictEqual(
+      controller.userData,
+      null,
+      'userData is initialized to null',
+    );
+    assert.strictEqual(
+      controller.profileURL,
+      null,
+      'profileURL is initialized to null',
+    );
+  });
+
+  test('it checks if setState updates the state correctly', function (assert) {
+    const controller = this.owner.lookup('controller:identity');
+
+    controller.setState('getStarted');
+
+    assert.strictEqual(
+      controller.state,
+      'getStarted',
+      'state is updated correctly',
+    );
+  });
+  test('action setState updates the state correctly', function (assert) {
+    const controller = this.owner.lookup('controller:identity');
+
+    controller.setState('not-linked');
+
+    assert.strictEqual(
+      controller.state,
+      'not-linked',
+      'state is updated correctly',
+    );
+  });
+});


### PR DESCRIPTION
Date: 14-05-25

Developer Name: @tejaskh3 

---

## Issue Ticket Number:-
- Closes #1051 

## Description:
- This PR fixes a bug during identity page reload where user with blocked status were displayed Get-Started Page instead of Status Blocked

Is Under Feature Flag

- [ ] Yes
- [x] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )


https://github.com/user-attachments/assets/9207870e-a767-4c6f-96f6-af1d93685402

https://github.com/user-attachments/assets/9d2168db-4400-496e-8c73-aca808b0cacd
