### PR TITLE
[My Site Migration] new-signup page (controller-unit-tests)

### DIFF
--- a/tests/constants/users-data.js
+++ b/tests/constants/users-data.js
@@ -61,3 +61,13 @@ export const nonSuperUserData = {
     super_user: false,
   },
 };
+
+export const fakeUserData = {
+  id: 'dZ0stx6x9ltOSMzON9kb',
+  github_created_at: 1625506111960,
+  github_display_name: 'Rishi Dharkar',
+  github_id: 'rishidharkar',
+  username: 'rishi-dharkar-1',
+  first_name: 'Rishi',
+  last_name: 'Dharkar',
+};

--- a/tests/unit/controllers/new-signup-test.js
+++ b/tests/unit/controllers/new-signup-test.js
@@ -118,7 +118,7 @@ module('Unit | Controller | new-signup', function (hooks) {
       fakeUserData.last_name,
     );
     assert.strictEqual(
-      result.username,
+      result,
       fakeUserData.username,
       'Generated username returned successfully',
     );
@@ -151,9 +151,7 @@ module('Unit | Controller | new-signup', function (hooks) {
       roles: { developer: true },
     };
 
-    sinon
-      .stub(controller, 'generateUsername')
-      .resolves({ username: fakeUserData.username });
+    sinon.stub(controller, 'generateUsername').resolves(fakeUserData.username);
     sinon.stub(controller, 'checkUserName').resolves(true);
     sinon.stub(controller, 'registerUser').resolves({ status: 204 });
 
@@ -174,8 +172,35 @@ module('Unit | Controller | new-signup', function (hooks) {
       roles: { developer: true },
     };
 
-    controller.generateUsername = sinon
-      .stub()
+    sinon.stub(controller, 'generateUsername').resolves(fakeUserData.username);
+    sinon.stub(controller, 'checkUserName').resolves(true);
+    sinon
+      .stub(controller, 'registerUser')
+      .throws(new Error(SIGNUP_ERROR_MESSAGES.others));
+
+    await controller.signup();
+
+    assert.strictEqual(
+      controller.error,
+      SIGNUP_ERROR_MESSAGES.others,
+      'Error message shown',
+    );
+    assert.false(controller.isLoading, 'Loading state reset');
+    assert.false(controller.isButtonDisabled, 'Button re-enabled after error');
+  });
+
+  test('signup catches error and shows correct error message (dev flag enabled)', async function (assert) {
+    controller.signupDev = 'true'; // replace signupDev with dev once dev is removed from new-signup
+    controller.signupDetails = {
+      firstName: fakeUserData.first_name,
+      lastName: fakeUserData.last_name,
+      username: 'mock-username',
+      roles: { developer: true },
+    };
+
+    sinon.stub(controller, 'checkUserName').resolves(true);
+    sinon
+      .stub(controller, 'newRegisterUser')
       .throws(new Error(SIGNUP_ERROR_MESSAGES.others));
 
     await controller.signup();

--- a/tests/unit/controllers/new-signup-test.js
+++ b/tests/unit/controllers/new-signup-test.js
@@ -6,6 +6,7 @@ import {
   NEW_SIGNUP_STEPS,
 } from 'website-www/constants/new-signup';
 import { fakeUserData } from 'website-www/tests/constants/users-data';
+import { TOAST_OPTIONS } from 'website-www/constants/toast-options';
 
 module('Unit | Controller | new-signup', function (hooks) {
   setupTest(hooks);
@@ -125,20 +126,29 @@ module('Unit | Controller | new-signup', function (hooks) {
   });
 
   test('generateUsername shows error toast on failure', async function (assert) {
-    fetchStub.rejects(new Error('API failed'));
-    assert.expect(2);
+    fetchStub.rejects(new Error(SIGNUP_ERROR_MESSAGES.usernameGeneration));
 
-    try {
-      await controller.generateUsername('Fail', 'Case');
-      assert.ok(false, 'Should throw error');
-    } catch (e) {
-      assert.ok(controller.toast.error.calledOnce, 'Toast error called');
-      assert.strictEqual(
-        e.message,
+    await assert.rejects(
+      controller.generateUsername(
+        fakeUserData.first_name,
+        fakeUserData.last_name,
+      ),
+      new Error(SIGNUP_ERROR_MESSAGES.usernameGeneration),
+      'Function should throw the correct error',
+    );
+
+    assert.ok(
+      controller.toast.error.calledOnce,
+      'Toast error should be called once',
+    );
+    assert.ok(
+      controller.toast.error.calledWith(
         SIGNUP_ERROR_MESSAGES.usernameGeneration,
-        'Correct error message thrown',
-      );
-    }
+        'error!',
+        TOAST_OPTIONS,
+      ),
+      'Toast error should be called with correct parameters',
+    );
   });
 
   test('signup handles successful flow', async function (assert) {

--- a/tests/unit/controllers/new-signup-test.js
+++ b/tests/unit/controllers/new-signup-test.js
@@ -1,0 +1,191 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'website-www/tests/helpers';
+import {
+  SIGNUP_ERROR_MESSAGES,
+  NEW_SIGNUP_STEPS,
+} from 'website-www/constants/new-signup';
+import { fakeUserData } from 'website-www/tests/constants/users-data';
+
+module('Unit | Controller | new-signup', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+  let fetchStub;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:new-signup');
+    controller.toast = {
+      success: sinon.stub(),
+      error: sinon.stub(),
+    };
+    controller.router = {
+      transitionTo: sinon.stub(),
+    };
+    fetchStub = sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+    fetchStub.restore();
+  });
+
+  test('correct initial currentStep for signup and step transitions', function (assert) {
+    assert.strictEqual(
+      controller.currentStep,
+      NEW_SIGNUP_STEPS[0],
+      'Starts at get-started step',
+    );
+
+    controller.send('changeStep', NEW_SIGNUP_STEPS[1]);
+    assert.strictEqual(
+      controller.currentStep,
+      NEW_SIGNUP_STEPS[1],
+      'Step updated to firstName',
+    );
+
+    controller.send('changeStep', NEW_SIGNUP_STEPS[2]);
+    assert.strictEqual(
+      controller.currentStep,
+      NEW_SIGNUP_STEPS[2],
+      'Step updated to lastName',
+    );
+
+    controller.send('changeStep', NEW_SIGNUP_STEPS[3]);
+    assert.strictEqual(
+      controller.currentStep,
+      NEW_SIGNUP_STEPS[3],
+      'Step updated to username',
+    );
+
+    controller.send('changeStep', NEW_SIGNUP_STEPS[4]);
+    assert.strictEqual(
+      controller.currentStep,
+      NEW_SIGNUP_STEPS[4],
+      'Step updated to role',
+    );
+  });
+
+  test('handleInputChange correctly updates value', function (assert) {
+    controller.send('handleInputChange', 'firstName', fakeUserData.first_name);
+    assert.strictEqual(
+      controller.signupDetails.firstName,
+      fakeUserData.first_name,
+      'First name updated',
+    );
+
+    controller.send('handleInputChange', 'lastName', fakeUserData.last_name);
+    assert.strictEqual(
+      controller.signupDetails.lastName,
+      fakeUserData.last_name,
+      'Last name updated',
+    );
+
+    controller.send('handleInputChange', 'username', fakeUserData.username);
+    assert.strictEqual(
+      controller.signupDetails.username,
+      fakeUserData.username,
+      'User name updated',
+    );
+  });
+
+  test('handleCheckboxInputChange updates roles and toggles button state', function (assert) {
+    controller.send('handleCheckboxInputChange', 'developer', true);
+    assert.true(controller.signupDetails.roles.developer, 'Developer role set');
+    assert.false(
+      controller.isButtonDisabled,
+      'Button enabled when one role is selected',
+    );
+
+    controller.send('handleCheckboxInputChange', 'developer', false);
+    assert.false(
+      controller.signupDetails.roles.developer,
+      'Developer role unset',
+    );
+    assert.true(
+      controller.isButtonDisabled,
+      'Button disabled when no roles selected',
+    );
+  });
+
+  test('generateUsername returns username on success', async function (assert) {
+    fetchStub.resolves({
+      json: () => Promise.resolve(fakeUserData),
+    });
+
+    const result = await controller.generateUsername(
+      fakeUserData.first_name,
+      fakeUserData.last_name,
+    );
+    assert.strictEqual(
+      result.username,
+      fakeUserData.username,
+      'Generated username returned successfully',
+    );
+  });
+
+  test('generateUsername shows error toast on failure', async function (assert) {
+    fetchStub.rejects(new Error('API failed'));
+    assert.expect(2);
+
+    try {
+      await controller.generateUsername('Fail', 'Case');
+      assert.ok(false, 'Should throw error');
+    } catch (e) {
+      assert.ok(controller.toast.error.calledOnce, 'Toast error called');
+      assert.strictEqual(
+        e.message,
+        SIGNUP_ERROR_MESSAGES.usernameGeneration,
+        'Correct error message thrown',
+      );
+    }
+  });
+
+  test('signup handles successful flow', async function (assert) {
+    const controller = this.owner.lookup('controller:new-signup');
+
+    controller.dev = 'false';
+    controller.signupDetails = {
+      firstName: fakeUserData.first_name,
+      lastName: fakeUserData.last_name,
+      roles: { developer: true },
+    };
+
+    sinon
+      .stub(controller, 'generateUsername')
+      .resolves({ username: fakeUserData.username });
+    sinon.stub(controller, 'checkUserName').resolves(true);
+    sinon.stub(controller, 'registerUser').resolves({ status: 204 });
+
+    await controller.signup();
+
+    assert.strictEqual(
+      controller.currentStep,
+      controller.LAST_STEP,
+      'Successfully moved to LAST_STEP',
+    );
+  });
+
+  test('signup catches error and shows correct error message', async function (assert) {
+    controller.dev = 'false';
+    controller.signupDetails = {
+      firstName: fakeUserData.first_name,
+      lastName: fakeUserData.last_name,
+      roles: { developer: true },
+    };
+
+    controller.generateUsername = sinon
+      .stub()
+      .throws(new Error(SIGNUP_ERROR_MESSAGES.others));
+
+    await controller.signup();
+
+    assert.strictEqual(
+      controller.error,
+      SIGNUP_ERROR_MESSAGES.others,
+      'Error message shown',
+    );
+    assert.false(controller.isLoading, 'Loading state reset');
+    assert.false(controller.isButtonDisabled, 'Button re-enabled after error');
+  });
+});


### PR DESCRIPTION
Date: 21-04-2025

Developer Name: @MayankBansal12 

---

## Issue Ticket Number:-

- #1021 
(Doesn't close the issue)

## Description:
- This PR overlaps with PR #1037 and refer to that for comments and reviews. This PR merges unit tests in the develop branch, which were previously wrongly merged in the feat branch.
- New-Signup page is being migrated from `my-site` to `main-site`.
- The PR contains unit tests for the new-signup controller moved in #1039
- New Signup page is under dev flag and using another signupDev flag to switch between new and old signup method.

Is Under Feature Flag

- [x] Yes
- [ ] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
Refer to #1037 for previous reviews.
The PR contains unit tests for new-signup controller and below are ss for ones added and local working proof

<img src="https://github.com/user-attachments/assets/4fe7c52f-bd1f-4a57-96f0-543b00e2249b" />
<img src="https://github.com/user-attachments/assets/42a7c167-17fd-412b-91c9-25e0bd1c7e3e" />