### PR TITLE
fix: change to last step after successful signup

### DIFF
--- a/app/controllers/new-signup.js
+++ b/app/controllers/new-signup.js
@@ -83,7 +83,7 @@ export default class NewSignupController extends Controller {
   }
 
   async registerUser(user) {
-    await apiRequest(SELF_USERS_URL, 'PATCH', user);
+    return await apiRequest(SELF_USERS_URL, 'PATCH', user);
   }
 
   async newRegisterUser(signupDetails, roles) {


### PR DESCRIPTION
Date: 16-05-2025

Developer Name: @MayankBansal12 

---

## Issue Ticket Number:-

- Closes #1055

## Description:
- Fixes a bug where even after successful user signup, the last step doesn't show up due to a missing `return` statement in response

- No test changes required as this helper function was missing a return response for promise and was being mocked in controller unit tests to resolve for particular success/failure response.

Is Under Feature Flag

- [x] Yes
- [ ] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?
- N/A

### Add relevant Screenshot below ( e.g test coverage etc. )

https://github.com/user-attachments/assets/313087b5-b75e-4088-8b8d-a31244801c4c


![image](https://github.com/user-attachments/assets/8b670df8-83d5-4175-8075-902eee6d082b)
(Note:- 6 tests were already skipped in the repo)