### PR TITLE
Fix: Removed target='_blank' from dropdown links to open in same tab

### DIFF
--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -116,6 +116,7 @@
     {{/if}}
   </div>
 
+  {{! Dropdown  }}
   <section
     data-test-dropdown
     class="menu {{if this.isMenuOpen 'active-menu' ''}}"
@@ -125,7 +126,6 @@
       @route={{this.HOME_PAGE}}
       class="menu__link"
       rel="noopener noreferrer"
-      target="_blank"
     >
       Home
     </LinkTo>
@@ -134,7 +134,6 @@
       href={{if @dev "/status?dev=true" this.MY_STATUS_URL}}
       class="menu__link"
       rel="noopener noreferrer"
-      target="_blank"
     >
       Status
     </a>
@@ -143,7 +142,6 @@
       href={{if @dev "/profile?dev=true" this.PROFILE_URL}}
       class="menu__link"
       rel="noopener noreferrer"
-      target="_blank"
     >
       Profile
     </a>
@@ -152,7 +150,6 @@
       href={{this.TASKS_URL}}
       class="menu__link"
       rel="noopener noreferrer"
-      target="_blank"
     >
       Tasks
     </a>
@@ -161,7 +158,6 @@
       href={{this.IDENTITY_URL}}
       class="menu__link"
       rel="noopener noreferrer"
-      target="_blank"
     >
       Identity
     </a>


### PR DESCRIPTION
Date: 09-06-2025

Developer Name:  Yash Rane

---

## Issue: #853:-

Fixes issue with dropdown links opening in a new tab instead of the same tab.


## Description:

This PR removes target="_blank" from the dropdown menu links (Status, Profile, Tasks, Identity) so that they now open in the same tab instead of a new tab. This aligns with user expectations for navigation within the same application.

Also ensures rel="noopener noreferrer" is retained for security where applicable.


Is Under Feature Flag:
- [ ] Yes
- [x] No

Database changes:

- [ ] Yes
- [x] No

Breaking changes:

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [x] Yes
- [ ] No

###  Screenshot / Proof:
UI behavior verified manually (click events open in same tab).

![Screenshot 2025-06-09 135819](https://github.com/user-attachments/assets/9a344dc6-df9e-47d8-96ba-1db581fa5330)

![Screenshot 2025-06-09 135851](https://github.com/user-attachments/assets/fc4c21e0-a439-4132-b462-7c554c559f3d)
