### PR TITLE
fix: make join publicly available

### DIFF
--- a/app/routes/join.js
+++ b/app/routes/join.js
@@ -3,9 +3,4 @@ import { inject as service } from '@ember/service';
 
 export default class JoinRoute extends Route {
   @service login;
-  @service router;
-
-  beforeModel() {
-    this.router.transitionTo('/page-not-found');
-  }
 }

--- a/tests/acceptance/render-footer-dynamically-test.js
+++ b/tests/acceptance/render-footer-dynamically-test.js
@@ -29,9 +29,13 @@ module('Acceptance | render footer dynamically', function (hooks) {
     assert.dom('[data-test-footer-repo-text]').exists();
   });
 
-  test('Should redirect to page-not-found when visiting /join', async function (assert) {
+  test('Should render only repo details in footer when visiting /join', async function (assert) {
     await visit('/join');
 
-    assert.strictEqual(currentURL(), '/page-not-found');
+    assert.strictEqual(currentURL(), '/join');
+
+    assert.dom('[data-test-events-section]').doesNotExist();
+    assert.dom('[data-test-footer-info]').doesNotExist();
+    assert.dom('[data-test-footer-repo-text]').exists();
   });
 });


### PR DESCRIPTION
Date: 11 June, 2024
Developer Name: @tejaskh3 

---

## Issue Ticket Number:-
https://github.com/Real-Dev-Squad/website-www/issues/1064

## Description:
- In this PR, we are making `/join` route publicly available, but hiding the steps to go there(this was already done)


Is Under Feature Flag
- [ ] Yes
- [x] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something, please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?
- [x] Yes
- [ ] No

Tested in staging?
- [x] Yes
- [ ] No

### Add relevant Screenshot below ( e.g, test coverage etc. )
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/9ed57ed0-4232-4424-a289-48d9010a97ed" />
![Uploading image.png…]()

