### PR TITLE
fix: use phoneNumber for socialLink in application

### DIFF
--- a/app/components/new-join-steps/base-step.js
+++ b/app/components/new-join-steps/base-step.js
@@ -42,7 +42,7 @@ export default class BaseStepComponent extends Component {
       funFact: app.intro?.funFact || '',
     }),
     newStepFourData: (app) => ({
-      phoneNo: app.socialLink?.phoneNo || '',
+      phoneNumber: app.socialLink?.phoneNumber || '',
       twitter: app.socialLink?.twitter || '',
       linkedin: app.socialLink?.linkedin || '',
       instagram: app.socialLink?.instagram || '',

--- a/app/components/new-join-steps/new-step-four.hbs
+++ b/app/components/new-join-steps/new-step-four.hbs
@@ -6,16 +6,16 @@
 
   <Reusables::InputBox
     @field="Phone Number"
-    @name="phoneNo"
+    @name="phoneNumber"
     @placeHolder="+91 80000 00000"
     @type="tel"
     @required={{true}}
-    @value={{this.data.phoneNo}}
+    @value={{this.data.phoneNumber}}
     @onInput={{this.inputHandler}}
     @variant="input--full-width"
   />
-  {{#if this.errorMessage.phoneNo}}
-    <div class="error__message">{{this.errorMessage.phoneNo}}</div>
+  {{#if this.errorMessage.phoneNumber}}
+    <div class="error__message">{{this.errorMessage.phoneNumber}}</div>
   {{/if}}
 
   <Reusables::InputBox

--- a/app/components/new-join-steps/new-step-four.js
+++ b/app/components/new-join-steps/new-step-four.js
@@ -11,7 +11,7 @@ export default class NewStepFourComponent extends BaseStepComponent {
   }
 
   stepValidation = {
-    phoneNo: NEW_STEP_LIMITS.stepFour.phoneNo,
+    phoneNumber: NEW_STEP_LIMITS.stepFour.phoneNumber,
     twitter: NEW_STEP_LIMITS.stepFour.twitter,
     linkedin: NEW_STEP_LIMITS.stepFour.linkedin,
     instagram: NEW_STEP_LIMITS.stepFour.instagram,
@@ -61,7 +61,7 @@ export default class NewStepFourComponent extends BaseStepComponent {
   }
 
   validateField(field, value) {
-    if (field === 'phoneNo') {
+    if (field === 'phoneNumber') {
       const trimmedValue = value?.trim() || '';
       const isValid = trimmedValue && phoneNumberRegex.test(trimmedValue);
       return {
@@ -73,7 +73,7 @@ export default class NewStepFourComponent extends BaseStepComponent {
   }
 
   formatError(field, result) {
-    if (field === 'phoneNo') {
+    if (field === 'phoneNumber') {
       if (result.isValid) return '';
       return 'Please enter a valid phone number (e.g., +91 80000 00000)';
     }

--- a/app/constants/applications.js
+++ b/app/constants/applications.js
@@ -24,7 +24,7 @@ export const mapSocialUrls = {
 };
 
 export const socialFields = [
-  'phoneNo',
+  'phoneNumber',
   'twitter',
   'linkedin',
   'instagram',

--- a/app/constants/new-join-form.js
+++ b/app/constants/new-join-form.js
@@ -52,7 +52,7 @@ export const NEW_STEP_LIMITS = {
     funFact: { min: 100, max: 500 },
   },
   stepFour: {
-    phoneNo: { min: 1 },
+    phoneNumber: { min: 1 },
     twitter: { min: 1 },
     github: { min: 1 },
     linkedin: { min: 1 },

--- a/tests/constants/application-data.js
+++ b/tests/constants/application-data.js
@@ -86,7 +86,7 @@ export const NEW_STEPS_APPLICATIONS_DATA = {
       'I built my first website at age 12 and have been coding ever since.',
   },
   stepFour: {
-    phoneNo: '+1-699-969-6969',
+    phoneNumber: '+1-699-969-6969',
     twitter: 'anujchhikara',
     github: 'anujchhikara',
     linkedin: 'anujchhikara',


### PR DESCRIPTION
Date: 21-02-26

Developer Name: @MayankBansal12 

---

## Issue Ticket Number:-

- `phoneNo` field is being used for new application, however it was changed recently and API now accepts `phoneNumber`

## Description:
- Update `phoneNo` to `phoneNumber` for new applications

Is Under Feature Flag

- [x] Yes
- [ ] No

Database changes

- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)

- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<details>
<summary>screencast </summary>


https://github.com/user-attachments/assets/975044cd-3207-4242-bd4f-63b947e1836d


</details>